### PR TITLE
Feature/#1 닉네임 화면 구현

### DIFF
--- a/FirstTeam/FirstTeam/Sources/Presentation/Nickname/View/NicknameView.swift
+++ b/FirstTeam/FirstTeam/Sources/Presentation/Nickname/View/NicknameView.swift
@@ -1,0 +1,134 @@
+//
+//  NicknameView.swift
+//  FirstTeam
+//
+//  Created by 김송희 on 11/23/24.
+//
+
+import UIKit
+
+final class NicknameView: BaseView {
+    
+    private let commentLabel = UILabel().then {
+        $0.text = "결정이 어려운 당신,\n닉네임을 입력해 주세요!"
+        $0.font = .pretendard(.title01)
+        $0.numberOfLines = 2
+    }
+    
+    let nicknameTextField = InsetTextField().then {
+        $0.placeholder = "닉네임을 입력해 주세요"
+        $0.font = .pretendard(.body02)
+        $0.layer.cornerRadius = 8
+        $0.backgroundColor = UIColor(resource: .gray01)
+        $0.textInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        $0.autocorrectionType = .no
+        $0.spellCheckingType = .no
+        $0.autocapitalizationType = .none
+        $0.clearsOnBeginEditing = false
+    }
+    
+    let myLengthLabel = UILabel().then {
+        $0.text = "0"
+        $0.font = .pretendard(.caption02)
+        $0.textColor = UIColor(resource: .gray05)
+    }
+    
+    private let slashLabel = UILabel().then {
+        $0.text = "/"
+        $0.font = .pretendard(.caption02)
+        $0.textColor = UIColor(resource: .gray05)
+    }
+    
+    private let totalLengthLabel = UILabel().then {
+        $0.text = "12"
+        $0.font = .pretendard(.caption02)
+        $0.textColor = UIColor(resource: .gray05)
+    }
+    
+    lazy var enterButton = UIButton().then {
+        $0.setTitle("제 결정을 도와주세요!", for: .normal)
+        $0.titleLabel?.textColor = .black
+        $0.titleLabel?.font = .pretendard(.subtitle01)
+        $0.backgroundColor = UIColor(resource: .gray05)
+        $0.layer.cornerRadius = 12
+        $0.isEnabled = false
+    }
+    
+    override func setStyle() {
+        self.backgroundColor = .white
+    }
+    
+    override func setUI() {
+        self.addSubviews(
+            commentLabel,
+            nicknameTextField,
+            myLengthLabel,
+            slashLabel,
+            totalLengthLabel,
+            enterButton
+        )
+    }
+    
+    override func setLayout() {
+        commentLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(152)
+            $0.leading.equalToSuperview().inset(20)
+        }
+        
+        nicknameTextField.snp.makeConstraints{
+            $0.top.equalTo(commentLabel.snp.bottom).offset(20)
+            $0.leading.equalToSuperview().inset(20)
+            $0.width.equalTo(332)
+            $0.height.equalTo(52)
+        }
+        
+        myLengthLabel.snp.makeConstraints{
+            $0.top.equalTo(nicknameTextField.snp.bottom).offset(4)
+            $0.trailing.equalTo(slashLabel.snp.leading).offset(-2)
+        }
+        
+        slashLabel.snp.makeConstraints{
+            $0.top.equalTo(nicknameTextField.snp.bottom).offset(4)
+            $0.trailing.equalTo(totalLengthLabel.snp.leading).offset(-2)
+        }
+        
+        totalLengthLabel.snp.makeConstraints{
+            $0.top.equalTo(nicknameTextField.snp.bottom).offset(4)
+            $0.trailing.equalToSuperview().inset(20)
+        }
+        
+        enterButton.snp.makeConstraints{
+            $0.width.equalTo(335)
+            $0.height.equalTo(54)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(36)
+        }
+    }
+    
+    func updateEnterButtonPosition(bottomInset: CGFloat, animationDuration: Double) {
+        enterButton.snp.updateConstraints { make in
+            make.bottom.equalToSuperview().inset(bottomInset)
+        }
+        
+        UIView.animate(withDuration: animationDuration) {
+            self.layoutIfNeeded()
+        }
+    }
+}
+
+class InsetTextField: UITextField {
+    var textInset = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
+    
+    override func textRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: textInset)
+    }
+    
+    override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: textInset)
+    }
+    
+    override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+        return bounds.inset(by: textInset)
+    }
+}
+

--- a/FirstTeam/FirstTeam/Sources/Presentation/Nickname/ViewController/NicknameViewController.swift
+++ b/FirstTeam/FirstTeam/Sources/Presentation/Nickname/ViewController/NicknameViewController.swift
@@ -1,0 +1,139 @@
+//
+//  NicknameViewController.swift
+//  FirstTeam
+//
+//  Created by 김송희 on 11/23/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class NicknameViewController: BaseViewController {
+    
+    private let nicknameView = NicknameView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        nicknameView.nicknameTextField.delegate = self
+        setObserver()
+        setTapGesture()
+        setAction()
+    }
+    
+    override func setStyle() {
+        view.backgroundColor = .white
+    }
+    
+    override func setUI() {
+        view.addSubviews(nicknameView)
+    }
+    
+    override func setLayout() {
+        nicknameView.snp.makeConstraints{
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    private func setAction() {
+        nicknameView.enterButton.addTarget(
+            self,
+            action: #selector(enterButtonTapped),
+            for: .touchUpInside
+        )
+    }
+    
+    @objc private func enterButtonTapped() {
+        let nickname = nicknameView.nicknameTextField.text ?? ""
+        UserDefaults.standard.set(nickname, forKey: "nickname")
+        
+        // TODO: push next view controller
+    }
+    
+    private func setObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow(_:)),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide(_:)),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+    
+    private func setTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        nicknameView.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+              let animationDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double else {
+            return
+        }
+        
+        let keyboardHeight = keyboardFrame.height
+        nicknameView.updateEnterButtonPosition(bottomInset: keyboardHeight + 20, animationDuration: animationDuration)
+    }
+    
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let animationDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double else {
+            return
+        }
+        nicknameView.updateEnterButtonPosition(bottomInset: 36, animationDuration: animationDuration)
+    }
+    
+    @objc private func dismissKeyboard() {
+        nicknameView.endEditing(true)
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+}
+
+extension NicknameViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(
+        _ textField: UITextField
+    ) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        let currentText = textField.text ?? ""
+        
+        guard let textRange = Range(range, in: currentText) else {
+            return false
+        }
+        let updatedText = currentText.replacingCharacters(in: textRange, with: string)
+        
+        if updatedText.count > 0 {
+            nicknameView.enterButton.backgroundColor = UIColor(resource: .green0)
+            nicknameView.enterButton.isEnabled = true
+        } else {
+            nicknameView.enterButton.backgroundColor = UIColor(resource: .gray05)
+            nicknameView.enterButton.isEnabled = false
+        }
+        
+        if updatedText.count > 12 {
+            return false
+        } else {
+            nicknameView.myLengthLabel.text = "\(updatedText.count)"
+            return updatedText.count <= 12
+        }
+    }
+}

--- a/FirstTeam/FirstTeam/Sources/Presentation/Splash/ViewController/SplashViewController.swift
+++ b/FirstTeam/FirstTeam/Sources/Presentation/Splash/ViewController/SplashViewController.swift
@@ -1,0 +1,38 @@
+//
+//  SplashViewController.swift
+//  FirstTeam
+//
+//  Created by 김송희 on 11/24/24.
+//
+
+import UIKit
+
+final class SplashViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .green
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            self.navigateToNicknameViewController()
+        }
+    }
+    
+    private func navigateToNicknameViewController() {
+        
+        var nextViewController = UIViewController()
+        
+        let token = UserDefaults.standard.string(forKey: "nickname") ?? ""
+            if token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                nextViewController = NicknameViewController()
+            } else {
+                // TODO: set home view controller as nextViewController
+            }
+
+        let navigationController = UINavigationController(rootViewController: nextViewController)
+        
+        navigationController.modalPresentationStyle = .fullScreen
+        self.present(navigationController, animated: true, completion: nil)
+    }
+}


### PR DESCRIPTION
## ⭐️ Related Issues
- Resolved: #1

## 🦉 What is the PR?
- 닉네임 화면 구현
- 스플래시 화면 일부 구현 (로직만)

## 🌪️ Changes
- 닉네임 화면에서 키패드 따라 버튼이 이동하도록
- 닉네임 화면에서 키패드 바깥 터치하거나 리턴 누르면 키패드 내려가도록
- 닉네임 화면에서 입력한 글자수 카운트, 버튼 활성화 변경
- 스플래시에서 닉네임 등록된 상태면 홈화면으로, 없는 상태면 닉네임 입력 화면으로

## 📺 Screenshot
| 닉네임 화면 |
| :-: |
| ![솝커톤 닉네임 화면](https://github.com/user-attachments/assets/985f5e8c-0669-4780-a782-26ad6b38276c) | 

## 💭 To Reviewers
- 닉네임 등록된 상태면 스플래시 화면에서 홈화면으로 연결 필요
- 닉네임 화면에서 버튼 누르면 고민 등록 화면으로 연결 필요